### PR TITLE
ios: generate reactTag for remote streams/tracks

### DIFF
--- a/ios/RCTWebRTC/RTCVideoViewManager.m
+++ b/ios/RCTWebRTC/RTCVideoViewManager.m
@@ -368,17 +368,20 @@ RCT_CUSTOM_VIEW_PROPERTY(objectFit, NSString *, RTCVideoView) {
   view.objectFit = e;
 }
 
-RCT_CUSTOM_VIEW_PROPERTY(streamURL, NSNumber, RTCVideoView) {
+RCT_CUSTOM_VIEW_PROPERTY(streamURL, NSString, RTCVideoView) {
   RTCVideoTrack *videoTrack;
 
   if (json) {
     NSString *streamId = (NSString *)json;
 
     WebRTCModule *module = [self.bridge moduleForName:@"WebRTCModule"];
-    RTCMediaStream *stream = module.mediaStreams[streamId];
-    NSArray *videoTracks = stream.videoTracks;
+    RTCMediaStream *stream = module.localStreams[streamId];
+    if (!stream) {
+      stream = module.remoteStreams[streamId];
+    }
+    NSArray *videoTracks = stream ? stream.videoTracks : nil;
 
-    videoTrack = videoTracks.count ? videoTracks[0] : nil;
+    videoTrack = videoTracks && videoTracks.count ? videoTracks[0] : nil;
   } else {
     videoTrack = nil;
   }

--- a/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
@@ -100,7 +100,7 @@ RCT_EXPORT_METHOD(getUserMedia:(NSDictionary *)constraints
         for (RTCMediaStreamTrack *track in [mediaStream performSelector:sel]) {
           NSString *trackId = track.trackId;
 
-          self.tracks[trackId] = track;
+          self.localTracks[trackId] = track;
           [tracks addObject:@{
                               @"enabled": @(track.isEnabled),
                               @"id": trackId,
@@ -111,7 +111,7 @@ RCT_EXPORT_METHOD(getUserMedia:(NSDictionary *)constraints
                               }];
         }
       }
-      self.mediaStreams[mediaStreamId] = mediaStream;
+      self.localStreams[mediaStreamId] = mediaStream;
       successCallback(@[ mediaStreamId, tracks ]);
     }
     errorCallback:^ (NSString *errorType, NSString *errorMessage) {
@@ -165,7 +165,7 @@ RCT_EXPORT_METHOD(getUserMedia:(NSDictionary *)constraints
 
   // If mediaStream contains no videoTracks and the constraints request such a
   // track, then run an iteration of the getUserMedia() algorithm to obtain
-  // local video content. 
+  // local video content.
   if (mediaStream.videoTracks.count == 0) {
     // constraints.video
     id videoConstraints = constraints[@"video"];
@@ -295,15 +295,15 @@ RCT_EXPORT_METHOD(getUserMedia:(NSDictionary *)constraints
 
 RCT_EXPORT_METHOD(mediaStreamRelease:(nonnull NSString *)streamID)
 {
-  RTCMediaStream *stream = self.mediaStreams[streamID];
+  RTCMediaStream *stream = self.localStreams[streamID];
   if (stream) {
     for (RTCVideoTrack *track in stream.videoTracks) {
-      [self.tracks removeObjectForKey:track.trackId];
+      [self.localTracks removeObjectForKey:track.trackId];
     }
     for (RTCAudioTrack *track in stream.audioTracks) {
-      [self.tracks removeObjectForKey:track.trackId];
+      [self.localTracks removeObjectForKey:track.trackId];
     }
-    [self.mediaStreams removeObjectForKey:streamID];
+    [self.localStreams removeObjectForKey:streamID];
   }
 }
 
@@ -333,15 +333,16 @@ RCT_EXPORT_METHOD(mediaStreamTrackGetSources:(RCTResponseSenderBlock)callback) {
 RCT_EXPORT_METHOD(mediaStreamTrackRelease:(nonnull NSString *)streamID : (nonnull NSString *)trackID)
 {
   // what's different to mediaStreamTrackStop? only call mediaStream explicitly?
-  RTCMediaStream *mediaStream = self.mediaStreams[streamID];
-  RTCMediaStreamTrack *track;
-  if (mediaStream && (track = self.tracks[trackID])) {
+  RTCMediaStream *mediaStream = self.localStreams[streamID];
+  RTCMediaStreamTrack *track = self.localTracks[trackID];
+  if (mediaStream && track) {
     track.isEnabled = NO;
+    // FIXME this is called when track is removed from the MediaStream,
+    // but it doesn't mean it can not be added back using MediaStream.addTrack
+    [self.localTracks removeObjectForKey:trackID];
     if ([track.kind isEqualToString:@"audio"]) {
-      [self.tracks removeObjectForKey:trackID];
       [mediaStream removeAudioTrack:(RTCAudioTrack *)track];
     } else if([track.kind isEqualToString:@"video"]) {
-      [self.tracks removeObjectForKey:trackID];
       [mediaStream removeVideoTrack:(RTCVideoTrack *)track];
     }
   }
@@ -349,7 +350,7 @@ RCT_EXPORT_METHOD(mediaStreamTrackRelease:(nonnull NSString *)streamID : (nonnul
 
 RCT_EXPORT_METHOD(mediaStreamTrackSetEnabled:(nonnull NSString *)trackID : (BOOL)enabled)
 {
-  RTCMediaStreamTrack *track = self.tracks[trackID];
+  RTCMediaStreamTrack *track = self.localTracks[trackID];
   if (track && track.isEnabled != enabled) {
     track.isEnabled = enabled;
   }
@@ -357,7 +358,7 @@ RCT_EXPORT_METHOD(mediaStreamTrackSetEnabled:(nonnull NSString *)trackID : (BOOL
 
 RCT_EXPORT_METHOD(mediaStreamTrackSwitchCamera:(nonnull NSString *)trackID)
 {
-  RTCMediaStreamTrack *track = self.tracks[trackID];
+  RTCMediaStreamTrack *track = self.localTracks[trackID];
   if (track) {
     RTCVideoTrack *videoTrack = (RTCVideoTrack *)track;
     RTCVideoSource *source = videoTrack.source;
@@ -370,10 +371,10 @@ RCT_EXPORT_METHOD(mediaStreamTrackSwitchCamera:(nonnull NSString *)trackID)
 
 RCT_EXPORT_METHOD(mediaStreamTrackStop:(nonnull NSString *)trackID)
 {
-  RTCMediaStreamTrack *track = self.tracks[trackID];
+  RTCMediaStreamTrack *track = self.localTracks[trackID];
   if (track) {
     track.isEnabled = NO;
-    [self.tracks removeObjectForKey:trackID];
+    [self.localTracks removeObjectForKey:trackID];
   }
 }
 

--- a/ios/RCTWebRTC/WebRTCModule.h
+++ b/ios/RCTWebRTC/WebRTCModule.h
@@ -22,7 +22,9 @@
 @property (nonatomic, strong) RTCPeerConnectionFactory *peerConnectionFactory;
 
 @property (nonatomic, strong) NSMutableDictionary<NSNumber *, RTCPeerConnection *> *peerConnections;
-@property (nonatomic, strong) NSMutableDictionary<NSString *, RTCMediaStream *> *mediaStreams;
-@property (nonatomic, strong) NSMutableDictionary<NSString *, RTCMediaStreamTrack *> *tracks;
+@property (nonatomic, strong) NSMutableDictionary<NSString *, RTCMediaStream *> *localStreams;
+@property (nonatomic, strong) NSMutableDictionary<NSString *, RTCMediaStreamTrack *> *localTracks;
+@property (nonatomic, strong) NSMutableDictionary<NSString *, RTCMediaStream *> *remoteStreams;
+@property (nonatomic, strong) NSMutableDictionary<NSString *, RTCMediaStreamTrack *> *remoteTracks;
 
 @end

--- a/ios/RCTWebRTC/WebRTCModule.m
+++ b/ios/RCTWebRTC/WebRTCModule.m
@@ -29,18 +29,24 @@
 //    [RTCPeerConnectionFactory initializeSSL];
 
     _peerConnections = [NSMutableDictionary new];
-    _mediaStreams = [NSMutableDictionary new];
-    _tracks = [NSMutableDictionary new];
+    _remoteStreams = [NSMutableDictionary new];
+    _remoteTracks = [NSMutableDictionary new];
+    _localStreams = [NSMutableDictionary new];
+    _localTracks = [NSMutableDictionary new];
   }
   return self;
 }
 
 - (void)dealloc
 {
-  [_tracks removeAllObjects];
-  _tracks = nil;
-  [_mediaStreams removeAllObjects];
-  _mediaStreams = nil;
+  [_remoteTracks removeAllObjects];
+  _remoteTracks = nil;
+  [_remoteStreams removeAllObjects];
+  _remoteStreams = nil;
+  [_localTracks removeAllObjects];
+  _localTracks = nil;
+  [_localStreams removeAllObjects];
+  _localStreams = nil;
 
   for (NSNumber *peerConnectionId in _peerConnections) {
     RTCPeerConnection *peerConnection = _peerConnections[peerConnectionId];


### PR DESCRIPTION
Will generate react tags for remote streams and tracks in the form of
{RTCPeerConnection react tag}_{stream id|track id}

This allows to receive streams/tracks with the same IDs through different PeerConnections.

I also opened this one (by mistake):
https://github.com/oney/react-native-webrtc/pull/261
Not sure which way is preferred ?