### PR TITLE
[Android] Implement mute/unmute events for remote video tracks

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/VideoTrackAdapter.java
+++ b/android/src/main/java/com/oney/WebRTCModule/VideoTrackAdapter.java
@@ -1,0 +1,150 @@
+package com.oney.WebRTCModule;
+
+import android.util.*;
+
+import org.webrtc.VideoTrack;
+import org.webrtc.VideoRenderer;
+import org.webrtc.VideoRenderer.I420Frame;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableMap;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Implements mute/unmute events for remote video tracks.
+ * Mute event is fired when there are no frames to be render for 1500ms
+ * initially and 500ms after the first frame was received.
+ */
+public class VideoTrackAdapter {
+    static final String TAG = VideoTrackAdapter.class.getCanonicalName();
+    static final long INITIAL_MUTE_DELAY = 3000;
+    static final long MUTE_DELAY = 1500;
+
+    private Map<String, TrackMuteUnmuteImpl> muteImplMap = new HashMap<>();
+
+    private Timer timer = new Timer("VideoTrackMutedTimer");
+
+    private final int peerConnectionId;
+
+    private final WebRTCModule webRTCModule;
+
+    public VideoTrackAdapter(WebRTCModule webRTCModule, int peerConnectionId) {
+        this.peerConnectionId = peerConnectionId;
+        this.webRTCModule = webRTCModule;
+    }
+
+    public void addAdapter(String streamReactTag, VideoTrack videoTrack) {
+        String trackId = videoTrack.id();
+        if (!muteImplMap.containsKey(trackId)) {
+            TrackMuteUnmuteImpl onMuteImpl
+                = new TrackMuteUnmuteImpl(streamReactTag, trackId);
+            Log.d(TAG, "Created adapter for " + trackId);
+            muteImplMap.put(trackId, onMuteImpl);
+            videoTrack.addRenderer(onMuteImpl.renderer);
+            onMuteImpl.start();
+        } else {
+            Log.w(
+                TAG, "Attempted to add adapter twice for track ID: " + trackId);
+        }
+    }
+
+    public void removeAdapter(VideoTrack videoTrack) {
+        String trackId = videoTrack.id();
+        TrackMuteUnmuteImpl onMuteImpl = muteImplMap.remove(trackId);
+        if (onMuteImpl != null) {
+            videoTrack.removeRenderer(onMuteImpl.renderer);
+            onMuteImpl.dispose();
+            Log.d(TAG, "Deleted adapter for " + trackId);
+        } else {
+            Log.w(TAG, "removeAdapter - no adapter for " + trackId);
+        }
+    }
+
+    /**
+     * Implements 'mute'/'unmute' events for remote video tracks through
+     * the {@link VideoRenderer#Callbacks} interface.
+     *
+     * TODO use VideoSink when becomes available in the used version
+     */
+    private class TrackMuteUnmuteImpl implements VideoRenderer.Callbacks {
+        private TimerTask emitMuteTask;
+        private volatile boolean disposed;
+        private AtomicInteger frameCounter;
+        private boolean mutedState;
+        private VideoRenderer renderer;
+        private final String streamReactTag;
+        private final String trackId;
+
+        TrackMuteUnmuteImpl(String streamReactTag, String trackId) {
+            this.streamReactTag = streamReactTag;
+            this.trackId = trackId;
+            this.renderer = new VideoRenderer(this);
+            this.frameCounter = new AtomicInteger();
+        }
+
+        @Override
+        public void renderFrame(I420Frame frame) {
+            VideoRenderer.renderFrameDone(frame);
+            frameCounter.addAndGet(1);
+        }
+
+        private void start() {
+            if (disposed) {
+                return;
+            }
+
+            synchronized (this) {
+                if (emitMuteTask != null) {
+                    emitMuteTask.cancel();
+                }
+                emitMuteTask = new TimerTask() {
+                    private int lastFrameNumber = frameCounter.get();
+
+                    @Override
+                    public void run() {
+                        if (disposed) {
+                            return;
+                        }
+                        boolean isMuted = lastFrameNumber == frameCounter.get();
+                        if (isMuted != mutedState) {
+                            mutedState = isMuted;
+                            emitMuteEvent(isMuted);
+                        }
+
+                        lastFrameNumber = frameCounter.get();
+                    }
+                };
+                timer.schedule(emitMuteTask, INITIAL_MUTE_DELAY, MUTE_DELAY);
+            }
+        }
+
+        private void emitMuteEvent(boolean muted) {
+            WritableMap params = Arguments.createMap();
+            params.putInt("peerConnectionId", peerConnectionId);
+            params.putString("streamReactTag", streamReactTag);
+            params.putString("trackId", trackId);
+            params.putBoolean("muted", muted);
+
+            Log.d(TAG,
+                (muted ? "Mute" : "Unmute" )
+                    + " event pcId: " + peerConnectionId
+                    + " streamTag: " + streamReactTag
+                    + " trackId: " + trackId);
+
+            VideoTrackAdapter.this.webRTCModule.sendEvent(
+                "mediaStreamTrackMuteChanged", params);
+        }
+
+        void dispose() {
+            disposed = true;
+            synchronized (this) {
+                if (emitMuteTask != null) {
+                    emitMuteTask.cancel();
+                    emitMuteTask = null;
+                }
+            }
+        }
+    }
+}

--- a/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.h
+++ b/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.h
@@ -15,6 +15,7 @@
 @property (nonatomic, strong) NSNumber *reactTag;
 @property (nonatomic, strong) NSMutableDictionary<NSString *, RTCMediaStream *> *remoteStreams;
 @property (nonatomic, strong) NSMutableDictionary<NSString *, RTCMediaStreamTrack *> *remoteTracks;
+@property (nonatomic, weak) id webRTCModule;
 
 @end
 

--- a/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
@@ -23,6 +23,7 @@
 #import "WebRTCModule.h"
 #import "WebRTCModule+RTCDataChannel.h"
 #import "WebRTCModule+RTCPeerConnection.h"
+#import "WebRTCModule+VideoTrackAdapter.h"
 
 @implementation RTCPeerConnection (React)
 
@@ -66,6 +67,16 @@
     objc_setAssociatedObject(self, @selector(remoteTracks), remoteTracks, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
+- (id)webRTCModule
+{
+    return objc_getAssociatedObject(self, _cmd);
+}
+
+- (void)setWebRTCModule:(id)webRTCModule
+{
+    objc_setAssociatedObject(self, @selector(webRTCModule), webRTCModule, OBJC_ASSOCIATION_ASSIGN);
+}
+
 @end
 
 @implementation WebRTCModule (RTCPeerConnection)
@@ -83,6 +94,8 @@ RCT_EXPORT_METHOD(peerConnectionInit:(RTCConfiguration*)configuration
   peerConnection.reactTag = objectID;
   peerConnection.remoteStreams = [NSMutableDictionary new];
   peerConnection.remoteTracks = [NSMutableDictionary new];
+  peerConnection.videoTrackAdapters = [NSMutableDictionary new];
+  peerConnection.webRTCModule = self;
   self.peerConnections[objectID] = peerConnection;
 }
 
@@ -237,6 +250,13 @@ RCT_EXPORT_METHOD(peerConnectionClose:(nonnull NSNumber *)objectID)
     return;
   }
 
+  // Remove video track adapters
+  for(RTCMediaStream *stream in [peerConnection.remoteStreams allValues]) {
+    for (RTCVideoTrack *track in stream.videoTracks) {
+      [peerConnection removeVideoTrackAdapter:track];
+    }
+  }
+
   [peerConnection close];
   [self.peerConnections removeObjectForKey:objectID];
 
@@ -383,21 +403,17 @@ RCT_EXPORT_METHOD(peerConnectionGetStats:(nonnull NSString *)trackID
 }
 
 - (void)peerConnection:(RTCPeerConnection *)peerConnection didAddStream:(RTCMediaStream *)stream {
+  NSString *streamReactTag = [[NSUUID UUID] UUIDString];
   NSMutableArray *tracks = [NSMutableArray array];
   for (RTCVideoTrack *track in stream.videoTracks) {
     peerConnection.remoteTracks[track.trackId] = track;
+    [peerConnection addVideoTrackAdapter:streamReactTag track:track];
     [tracks addObject:@{@"id": track.trackId, @"kind": track.kind, @"label": track.trackId, @"enabled": @(track.isEnabled), @"remote": @(YES), @"readyState": @"live"}];
   }
   for (RTCAudioTrack *track in stream.audioTracks) {
     peerConnection.remoteTracks[track.trackId] = track;
     [tracks addObject:@{@"id": track.trackId, @"kind": track.kind, @"label": track.trackId, @"enabled": @(track.isEnabled), @"remote": @(YES), @"readyState": @"live"}];
   }
-
-  NSString *streamReactTag;
-  // Make sure ID does not exist across local and remote streams (for any peerConnection)
-  do {
-    streamReactTag = [[NSUUID UUID] UUIDString];
-  } while ([self streamForReactTag:streamReactTag]);
 
   peerConnection.remoteStreams[streamReactTag] = stream;
   [self.bridge.eventDispatcher sendDeviceEventWithName:@"peerConnectionAddedStream"
@@ -416,6 +432,7 @@ RCT_EXPORT_METHOD(peerConnectionGetStats:(nonnull NSString *)trackID
     return;
   }
   for (RTCVideoTrack *track in stream.videoTracks) {
+    [peerConnection removeVideoTrackAdapter:track];
     [peerConnection.remoteTracks removeObjectForKey:track.trackId];
   }
   for (RTCAudioTrack *track in stream.audioTracks) {
@@ -467,6 +484,11 @@ RCT_EXPORT_METHOD(peerConnectionGetStats:(nonnull NSString *)trackID
   [self.bridge.eventDispatcher sendDeviceEventWithName:@"peerConnectionDidOpenDataChannel"
                                                   body:body];
 }
+
+- (void)peerConnection:(nonnull RTCPeerConnection *)peerConnection didRemoveIceCandidates:(nonnull NSArray<RTCIceCandidate *> *)candidates {
+  // TODO
+}
+
 
 /**
  * Parses the constraint keys and values of a specific JavaScript object into

--- a/ios/RCTWebRTC/WebRTCModule+VideoTrackAdapter.h
+++ b/ios/RCTWebRTC/WebRTCModule+VideoTrackAdapter.h
@@ -1,0 +1,13 @@
+
+#import "WebRTCModule.h"
+#import <WebRTC/RTCPeerConnection.h>
+
+@interface RTCPeerConnection (VideoTrackAdapter)
+
+@property (nonatomic, strong) NSMutableDictionary<NSString *,  id> *videoTrackAdapters;
+
+- (void)addVideoTrackAdapter:(NSString*)streamReactId track:(RTCVideoTrack*)track;
+- (void)removeVideoTrackAdapter:(RTCVideoTrack*)track;
+
+@end
+

--- a/ios/RCTWebRTC/WebRTCModule+VideoTrackAdapter.m
+++ b/ios/RCTWebRTC/WebRTCModule+VideoTrackAdapter.m
@@ -1,0 +1,178 @@
+
+#import <Foundation/Foundation.h>
+#include <libkern/OSAtomic.h>
+#import <objc/runtime.h>
+
+#import <React/RCTBridge.h>
+#import <React/RCTEventDispatcher.h>
+
+#import <WebRTC/RTCVideoRenderer.h>
+#import <WebRTC/RTCVideoTrack.h>
+
+#import "WebRTCModule.h"
+#import "WebRTCModule+RTCPeerConnection.h"
+#import "WebRTCModule+VideoTrackAdapter.h"
+
+/* Mute detection timer intervals. The initial timeout will be longer to
+ * accommodate for source startup.
+ */
+static const NSTimeInterval INITIAL_MUTE_DELAY = 3;
+static const NSTimeInterval MUTE_DELAY = 1.5;
+
+/* Entity responsible for detecting track mute / unmute events. It's implemented
+ * as a video renderer, which counts the number of frames, and if it sees them
+ * stalled for the default interval it will emit a mute event. If frame keep
+ * being received, the track unmute event will be emitted.
+ */
+@interface TrackMuteDetector : NSObject<RTCVideoRenderer>
+
+@property (copy, nonatomic) NSNumber *peerConnectionId;
+@property (copy, nonatomic) NSString *streamReactTag;
+@property (copy, nonatomic) NSString *trackId;
+@property (weak, nonatomic) WebRTCModule *module;
+
+@end
+
+@implementation TrackMuteDetector {
+    BOOL _disposed;
+    volatile int64_t _frameCount;
+    BOOL _muted;
+    dispatch_source_t _timer;
+}
+
+- (instancetype)initWith:(NSNumber*)peerConnectionId
+          streamReactTag:(NSString*)streamReactTag
+                 trackId:(NSString*)trackId
+            webRTCModule:(WebRTCModule*)module {
+    self = [super init];
+    if (self) {
+        self.peerConnectionId = peerConnectionId;
+        self.streamReactTag = streamReactTag;
+        self.trackId = trackId;
+        self.module = module;
+
+        _disposed = NO;
+        _frameCount = 0;
+        _muted = NO;
+        _timer = nil;
+    }
+
+    return self;
+}
+
+- (void)dispose {
+    _disposed = YES;
+    if (_timer != nil) {
+        dispatch_source_cancel(_timer);
+        _timer = nil;
+    }
+}
+
+- (void)emitMuteEvent:(BOOL)muted {
+    [self.module.bridge.eventDispatcher
+        sendDeviceEventWithName:@"mediaStreamTrackMuteChanged"
+                   body:@{@"peerConnectionId": self.peerConnectionId,
+                          @"streamReactTag": self.streamReactTag,
+                          @"trackId": self.trackId,
+                          @"muted": @(muted)}];
+    NSLog(@"[VideoTrackAdapter] %@ event for %@ %@ %@",
+          muted ? @"Mute" : @"Unmute",
+          self.peerConnectionId,
+          self.streamReactTag,
+          self.trackId);
+}
+
+- (void)start {
+    if (_disposed) {
+        return;
+    }
+
+    if (_timer != nil) {
+        dispatch_source_cancel(_timer);
+    }
+
+    // Create a timer using GCD, since NSTimer requires a runloop to be present
+    // on the calling thread.
+    _timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER,
+                                    0, 0, dispatch_get_main_queue());
+
+    // Schedule the timer with a larger initial delay than the interval.
+    dispatch_source_set_timer(
+        _timer, dispatch_time(DISPATCH_TIME_NOW, INITIAL_MUTE_DELAY * NSEC_PER_SEC),
+        MUTE_DELAY * NSEC_PER_SEC, (1ull * NSEC_PER_SEC) / 10);
+
+    __block int64_t lastFrameCount = _frameCount;
+    dispatch_source_set_event_handler(_timer, ^() {
+        if (_disposed) {
+            return;
+        }
+
+        BOOL isMuted = lastFrameCount == _frameCount;
+        if (isMuted != _muted) {
+            _muted = isMuted;
+            [self emitMuteEvent:isMuted];
+        }
+
+        lastFrameCount = _frameCount;
+    });
+
+    dispatch_resume(_timer);
+}
+
+- (void)renderFrame:(nullable RTCVideoFrame *)frame {
+    OSAtomicIncrement64(&_frameCount);
+}
+
+- (void)setSize:(CGSize)size {
+    // XXX unneeded for our purposes, but part of RTCVideoRenderer.
+}
+
+@end
+
+@implementation RTCPeerConnection (VideoTrackAdapter)
+
+- (NSMutableDictionary<NSString *, id> *)videoTrackAdapters
+{
+    return objc_getAssociatedObject(self, _cmd);
+}
+
+- (void)setVideoTrackAdapters:(NSMutableDictionary<NSString *, id> *)videoTrackAdapters
+{
+    objc_setAssociatedObject(self, @selector(videoTrackAdapters), videoTrackAdapters, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+- (void)addVideoTrackAdapter:(NSString*)streamReactId track:(RTCVideoTrack*)track {
+    NSString* trackId = track.trackId;
+    if ([self.videoTrackAdapters objectForKey:trackId] != nil) {
+        NSLog(@"[VideoTrackAdapter] Adapter already exists for track %@", trackId);
+        return;
+    }
+
+    TrackMuteDetector* muteDetector
+        = [[TrackMuteDetector alloc] initWith:self.reactTag
+                                streamReactTag:streamReactId
+                                      trackId:trackId
+                                 webRTCModule:self.webRTCModule];
+    [self.videoTrackAdapters setObject:muteDetector forKey:trackId];
+    [track addRenderer:muteDetector];
+    [muteDetector start];
+
+    NSLog(@"[VideoTrackAdapter] Adapter created for track %@", trackId);
+}
+
+- (void)removeVideoTrackAdapter:(RTCVideoTrack*)track {
+    NSString* trackId = track.trackId;
+    TrackMuteDetector* muteDetector
+        = [self.videoTrackAdapters objectForKey:trackId];
+    if (muteDetector == nil) {
+        NSLog(@"[VideoTrackAdapter] Adapter doesn't exist for track %@", trackId);
+        return;
+    }
+
+    [track removeRenderer:muteDetector];
+    [muteDetector dispose];
+    [self.videoTrackAdapters removeObjectForKey:trackId];
+    NSLog(@"[VideoTrackAdapter] Adapter removed for track %@", trackId);
+}
+
+@end


### PR DESCRIPTION
When a remote video track is not rendering any video it will emit the
muted event. When video recovers it will go back to the unmuted state.

This is what Chrome currently does for remote video tracks.

Ref:
https://chromium.googlesource.com/chromium/src.git/+/master/content/renderer/media/video_track_adapter.cc