### PR TITLE
ios: fix build when using `use_frameworks!`

### DIFF
--- a/react-native-webrtc.podspec
+++ b/react-native-webrtc.podspec
@@ -20,4 +20,5 @@ Pod::Spec.new do |s|
   s.framework           = 'AudioToolbox','AVFoundation', 'CoreAudio', 'CoreGraphics', 'CoreVideo', 'GLKit', 'VideoToolbox'
   s.ios.vendored_frameworks = 'ios/WebRTC.framework'
   s.xcconfig            = { 'OTHER_LDFLAGS' => '-framework WebRTC' }
+  s.dependency          'React'
 end


### PR DESCRIPTION
This applies to those using CocoaPods for installing this package.