### PR TITLE
WebRTCModule use worker queue instead of the main queue

### DIFF
--- a/ios/RCTWebRTC/WebRTCModule.m
+++ b/ios/RCTWebRTC/WebRTCModule.m
@@ -16,6 +16,8 @@
 
 @interface WebRTCModule ()
 
+@property(nonatomic, strong) dispatch_queue_t workerQueue;
+
 @end
 
 @implementation WebRTCModule
@@ -54,6 +56,11 @@
     _peerConnections = [NSMutableDictionary new];
     _localStreams = [NSMutableDictionary new];
     _localTracks = [NSMutableDictionary new];
+
+    dispatch_queue_attr_t attributes =
+    dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_SERIAL,
+                                            QOS_CLASS_USER_INITIATED, -1);
+    _workerQueue = dispatch_queue_create("WebRTCModule.queue", attributes);
   }
   return self;
 }
@@ -77,7 +84,7 @@ RCT_EXPORT_MODULE();
 
 - (dispatch_queue_t)methodQueue
 {
-  return dispatch_get_main_queue();
+  return _workerQueue;
 }
 
 @end


### PR DESCRIPTION
Tested with profiler, and confirmed that the module method calls are resolved in the specified worker queue. Also checked that are no main thread API call exceptions.