### PR TITLE
ios: update RTCPeerConnectionFactory initialization

### DIFF
--- a/ios/RCTWebRTC/WebRTCModule.h
+++ b/ios/RCTWebRTC/WebRTCModule.h
@@ -16,6 +16,7 @@
 #import <WebRTC/RTCPeerConnection.h>
 #import <WebRTC/RTCAudioTrack.h>
 #import <WebRTC/RTCVideoTrack.h>
+#import <WebRTC/RTCVideoCodecFactory.h>
 
 @interface WebRTCModule : NSObject <RCTBridgeModule>
 

--- a/ios/RCTWebRTC/WebRTCModule.m
+++ b/ios/RCTWebRTC/WebRTCModule.m
@@ -50,8 +50,13 @@
 {
   self = [super init];
   if (self) {
-    _peerConnectionFactory = [RTCPeerConnectionFactory new];
-//    [RTCPeerConnectionFactory initializeSSL];
+    RTCDefaultVideoDecoderFactory *decoderFactory
+      = [[RTCDefaultVideoDecoderFactory alloc] init];
+    RTCDefaultVideoEncoderFactory *encoderFactory
+      = [[RTCDefaultVideoEncoderFactory alloc] init];
+    _peerConnectionFactory
+      = [[RTCPeerConnectionFactory alloc] initWithEncoderFactory:encoderFactory
+                                                  decoderFactory:decoderFactory];
 
     _peerConnections = [NSMutableDictionary new];
     _localStreams = [NSMutableDictionary new];


### PR DESCRIPTION
Somewhere around M67 this got refactored and the old way of doing things
is now deprecated.