### PR TITLE
android: workaround RN permissions bug

### DIFF
--- a/Permissions.js
+++ b/Permissions.js
@@ -47,7 +47,7 @@ class Permissions {
     _requestPermissionAndroid(perm) {
         return new Promise((resolve, reject) => {
             PermissionsAndroid.request(perm).then(
-                granted => resolve(granted === PermissionsAndroid.RESULTS.GRANTED),
+                granted => resolve(granted === true || granted === PermissionsAndroid.RESULTS.GRANTED),
                 () => resolve(false));
         });
     }


### PR DESCRIPTION
On Android < M the request function would return a boolean instead of
returning a defined constant. This was fixed on RN 0.57.

https://github.com/facebook/react-native/commit/4e1abdd74dc4127a86d62e7750d01d39bb781c08